### PR TITLE
feat(agent-client): optional headers

### DIFF
--- a/arc-agent-client/src/main/kotlin/AgentClient.kt
+++ b/arc-agent-client/src/main/kotlin/AgentClient.kt
@@ -18,7 +18,7 @@ interface AgentClient {
      * If an url is not provided, the client will use the default url.
      * If an agent name is not provided, the server will use the default agent.
      */
-    suspend fun callAgent(agentRequest: AgentRequest, agentName: String? = null, url: String? = null): Flow<AgentResult>
+    suspend fun callAgent(agentRequest: AgentRequest, agentName: String? = null, url: String? = null, requestHeaders: Map<String, Any> = emptyMap()): Flow<AgentResult>
 }
 
 /**

--- a/arc-agent-client/src/main/kotlin/graphql/GraphQlAgentClient.kt
+++ b/arc-agent-client/src/main/kotlin/graphql/GraphQlAgentClient.kt
@@ -10,6 +10,7 @@ import ai.ancf.lmos.arc.api.AgentRequest
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.websocket.*
+import io.ktor.http.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.encodeToString
@@ -38,10 +39,13 @@ class GraphQlAgentClient(private val defaultUrl: String? = null) : AgentClient, 
         }
     }
 
-    override suspend fun callAgent(agentRequest: AgentRequest, agentName: String?, url: String?) = flow {
+    override suspend fun callAgent(agentRequest: AgentRequest, agentName: String?, url: String?, requestHeaders: Map<String, Any>) = flow {
         if (url == null && defaultUrl == null) error("Agent Url not provided!")
         val opId = UUID.randomUUID().toString()
         client.webSocket(url ?: defaultUrl!!) {
+            headers {
+                requestHeaders.forEach { (key, value) -> append(key, value.toString()) }
+            }
             initConnection()
             sendSubscription(opId, agentRequest, agentName)
             while (closing.get().not()) {


### PR DESCRIPTION
provision to pass request headers (optional) in agent call.
this is required to support traffic routing to multiple versions of same agent