### PR TITLE
init block within arc DSL

### DIFF
--- a/arc-agents/src/main/kotlin/ChatAgent.kt
+++ b/arc-agents/src/main/kotlin/ChatAgent.kt
@@ -47,9 +47,14 @@ class ChatAgent(
     private val toolsProvider: suspend DSLContext.() -> Unit,
     private val filterOutput: suspend OutputFilterContext.() -> Unit,
     private val filterInput: suspend InputFilterContext.() -> Unit,
+    val init: DSLContext.() -> Unit,
 ) : Agent<Conversation, Conversation> {
 
     private val log = LoggerFactory.getLogger(javaClass)
+
+    init {
+        init.invoke(BasicDSLContext(beanProvider))
+    }
 
     override suspend fun execute(input: Conversation, context: Set<Any>): Result<Conversation, AgentFailedException> {
         return withLogContext(mapOf(AGENT_LOG_CONTEXT_KEY to name)) {

--- a/arc-agents/src/main/kotlin/dsl/AgentDefinitionContext.kt
+++ b/arc-agents/src/main/kotlin/dsl/AgentDefinitionContext.kt
@@ -80,4 +80,9 @@ class AgentDefinition {
     fun filterInput(fn: suspend InputFilterContext.() -> Unit) {
         inputFilter = fn
     }
+
+    var init: DSLContext.() -> Unit = { }
+    fun init(fn: DSLContext.() -> Unit) {
+        init = fn
+    }
 }

--- a/arc-agents/src/main/kotlin/dsl/AgentFactory.kt
+++ b/arc-agents/src/main/kotlin/dsl/AgentFactory.kt
@@ -30,6 +30,7 @@ class ChatAgentFactory(private val beanProvider: BeanProvider) : AgentFactory<Ch
             agentDefinition.toolsProvider,
             agentDefinition.outputFilter,
             agentDefinition.inputFilter,
+            agentDefinition.init,
         )
     }
 }

--- a/arc-scripting/src/main/kotlin/agents/AgentScriptEngine.kt
+++ b/arc-scripting/src/main/kotlin/agents/AgentScriptEngine.kt
@@ -41,7 +41,8 @@ class KtsAgentScriptEngine : AgentScriptEngine {
         val res = evalScript(script, context)
         val errors = res.reports.getErrors()
         if (errors.isNotEmpty()) failWith { ScriptFailedException(errors.joinToString()) }
-        res.valueOrNull()?.returnValue
+        val returnValue = res.valueOrNull()?.returnValue
+        return@result if (returnValue is ResultValue.Error) failWith { ScriptFailedException("Script failed with error: $returnValue") } else returnValue
     }
 
     private fun List<ScriptDiagnostic>.getErrors(): List<String> = buildList {

--- a/arc-scripting/src/test/kotlin/AgentTest.kt
+++ b/arc-scripting/src/test/kotlin/AgentTest.kt
@@ -4,11 +4,15 @@
 
 package ai.ancf.lmos.arc.scripting
 
+import ai.ancf.lmos.arc.agents.ArcException
 import ai.ancf.lmos.arc.agents.ChatAgent
 import ai.ancf.lmos.arc.agents.User
-import ai.ancf.lmos.arc.agents.conversation.AssistantMessage
-import ai.ancf.lmos.arc.agents.conversation.ConversationMessage
-import ai.ancf.lmos.arc.agents.conversation.toConversation
+import ai.ancf.lmos.arc.agents.conversation.*
+import ai.ancf.lmos.arc.agents.functions.LLMFunction
+import ai.ancf.lmos.arc.agents.llm.ChatCompleter
+import ai.ancf.lmos.arc.agents.llm.ChatCompleterProvider
+import ai.ancf.lmos.arc.agents.llm.ChatCompletionSettings
+import ai.ancf.lmos.arc.core.Result
 import ai.ancf.lmos.arc.core.Success
 import ai.ancf.lmos.arc.core.getOrThrow
 import io.mockk.coEvery
@@ -36,5 +40,37 @@ class AgentTest : TestBase() {
         }
 
         assertThat(input.captured.size).isEqualTo(2)
+    }
+
+    @Test
+    fun `test agent execution with one time loading from init block`(): Unit = runBlocking {
+        val assistantMessage: String
+        assistantMessage = testBeanProvider.setContext(
+            setOf(
+                ChatCompleterProvider {
+                    object : ChatCompleter {
+                        override suspend fun complete(
+                            messages: List<ConversationMessage>,
+                            functions: List<LLMFunction>?,
+                            settings: ChatCompletionSettings?,
+                        ): Result<AssistantMessage, ArcException> {
+                            return messages.findLast { it is SystemMessage }?.let {
+                                Success(AssistantMessage(it.content))
+                            } ?: throw ArcException("No system message found")
+                        }
+                    }
+                },
+            ),
+        ) {
+            val agent = eval("kb-summarizer.agent.kts") as ChatAgent
+            // execute twice.
+            agent.execute("A question".toConversation(User("test")))
+                .getOrThrow().transcript.findLast { it is AssistantMessage }?.content ?: "No assistant message found"
+            agent.execute("A question".toConversation(User("test")))
+                .getOrThrow().transcript.findLast { it is AssistantMessage }?.content ?: "No assistant message found"
+        }
+
+        assertThat(assistantMessage).contains("This is a file to test init block of arc agents.")
+        assertThat(assistantMessage).contains("Number of times file loaded = 1")
     }
 }

--- a/arc-scripting/src/test/resources/kb-summarizer.agent.kts
+++ b/arc-scripting/src/test/resources/kb-summarizer.agent.kts
@@ -1,0 +1,36 @@
+import java.io.File
+
+// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+
+agent {
+    name = "kb-summarizer"
+    description = "Agent that provides weather data."
+    var knowledgeSource = ""
+    var numberOfTimesFileLoaded = 0
+    init = {
+        knowledgeSource = File("src/test/resources/knowledge-source.txt").readText()
+        numberOfTimesFileLoaded++
+    }
+    systemPrompt = {
+        """
+       You are a professional document summarizer.
+       You have access to the knowledge file. The knowledge content is as follows:
+       $knowledgeSource
+       Keep your answer short and concise.
+       if you cannot help the user, simply reply "I cant help you"
+       Number of times file loaded = $numberOfTimesFileLoaded
+     """
+    }
+    filterInput {
+        "A transformed question" replaces "A question"
+        -"Bad Word"
+        -"Malware.*".toRegex()
+    }
+    filterOutput {
+        -"Bad Word"
+        -"Malware.*".toRegex()
+    }
+}

--- a/arc-scripting/src/test/resources/knowledge-source.txt
+++ b/arc-scripting/src/test/resources/knowledge-source.txt
@@ -1,0 +1,1 @@
+This is a file to test init block of arc agents.

--- a/arc-scripting/src/test/resources/knowledge-source.txt
+++ b/arc-scripting/src/test/resources/knowledge-source.txt
@@ -1,1 +1,5 @@
+// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
 This is a file to test init block of arc agents.


### PR DESCRIPTION
Currently, arc DSL does not support one-time loading of resources that might be needed in need systemPrompt, inputFilter or output filter. For example - Agent wants to load the content of the file from s3 and then use the same in the system prompt. The file content is not changing per request so this can be loaded at the initialisation of the agent.

This PR introduces init block within arc DSL. We can use this block to write implementations that should be loaded only once but used everytime agent executes.