### PR TITLE
Added developerPrompt in arc DSL.

### DIFF
--- a/arc-agents/src/main/kotlin/dsl/AgentDefinitionContext.kt
+++ b/arc-agents/src/main/kotlin/dsl/AgentDefinitionContext.kt
@@ -85,4 +85,14 @@ class AgentDefinition {
     fun init(fn: DSLContext.() -> Unit) {
         init = fn
     }
+
+    var developerPrompt: suspend DSLContext.() -> String = { "" }
+        get() = {
+            val result = field()
+            if (this is BasicDSLContext) {
+                (output.get() + result).trimIndent()
+            } else {
+                result.trimIndent()
+            }
+        }
 }

--- a/arc-agents/src/main/kotlin/dsl/AgentFactory.kt
+++ b/arc-agents/src/main/kotlin/dsl/AgentFactory.kt
@@ -27,6 +27,7 @@ class ChatAgentFactory(private val beanProvider: BeanProvider) : AgentFactory<Ch
             agentDefinition.settings,
             beanProvider,
             agentDefinition.systemPrompt,
+            agentDefinition.developerPrompt,
             agentDefinition.toolsProvider,
             agentDefinition.outputFilter,
             agentDefinition.inputFilter,

--- a/arc-agents/src/test/kotlin/dsl/AgentDeveloperPromptTest.kt
+++ b/arc-agents/src/test/kotlin/dsl/AgentDeveloperPromptTest.kt
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.eclipse.lmos.arc.agents.dsl
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.lmos.arc.agents.ChatAgent
+import org.eclipse.lmos.arc.agents.TestBase
+import org.junit.jupiter.api.Test
+
+class AgentDeveloperPromptTest : TestBase() {
+
+    @Test
+    fun `test DeveloperPrompt output`(): Unit = runBlocking {
+        val agent = agent {
+            name = ""
+            description = ""
+            developerPrompt = {
+                +"""first"""
+                if (false) +"error"
+                if (true) +"second"
+                """third"""
+            }
+        }
+        val (input, _) = executeAgent(agent as ChatAgent, "bad stuff here")
+        assertThat(input.first().content).isEqualTo("firstsecondthird")
+    }
+
+    @Test
+    fun `test developerPrompt has access to context beans`(): Unit = runBlocking {
+        val testString = "testString"
+        val agent = agent {
+            name = ""
+            description = ""
+            developerPrompt = {
+                get<String>()
+            }
+        }
+        testBeanProvider.setContext(setOf(testString)) {
+            val (input, _) = executeAgent(agent as ChatAgent, "bad stuff here")
+            assertThat(input.first().content).isEqualTo("testString")
+        }
+    }
+}


### PR DESCRIPTION
The developer can use this prompt if the underlying model can handle the Developer Message. Developer messages are going to be the key to using advance models like o1. Refer - https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages 

I will update the [documentation](https://github.com/eclipse-lmos/website/tree/source/docs/arc) after conclusion of this PR.