### PR TITLE
Update license headers to 2025 and include "and others"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project has adopted the [Contributor Covenant](https://www.contributor-cove
 By participating in this project, you agree to abide by its [Code of Conduct](./CODE_OF_CONDUCT.md) at all times.
 
 ## Licensing
-Copyright (c) 2024 Deutsche Telekom AG.
+Copyright (c) 2025 Deutsche Telekom AG and others.
 
 Sourcecode licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) (the "License"); you may not use this project except in compliance with the License.
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 # 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -31,7 +31,7 @@ path = [
     "**/chat/*.json",
 ]
 precedence = "override"
-SPDX-FileCopyrightText = "2024 Deutsche Telekom AG"
+SPDX-FileCopyrightText = "2025 Deutsche Telekom AG and others"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]

--- a/arc-agent-client/build.gradle.kts
+++ b/arc-agent-client/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agent-client/src/main/kotlin/AgentClient.kt
+++ b/arc-agent-client/src/main/kotlin/AgentClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agent-client/src/main/kotlin/graphql/AgentSubscription.kt
+++ b/arc-agent-client/src/main/kotlin/graphql/AgentSubscription.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agent-client/src/main/kotlin/graphql/DataTypes.kt
+++ b/arc-agent-client/src/main/kotlin/graphql/DataTypes.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agent-client/src/main/kotlin/graphql/GraphQlAgentClient.kt
+++ b/arc-agent-client/src/main/kotlin/graphql/GraphQlAgentClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agent-client/src/test/kotlin/AgentClientTest.kt
+++ b/arc-agent-client/src/test/kotlin/AgentClientTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agent-client/src/test/kotlin/TestApplication.kt
+++ b/arc-agent-client/src/test/kotlin/TestApplication.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agent-client/src/test/resources/application.yml
+++ b/arc-agent-client/src/test/resources/application.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/build.gradle.kts
+++ b/arc-agents/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/Agent.kt
+++ b/arc-agents/src/main/kotlin/Agent.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/AgentEvents.kt
+++ b/arc-agents/src/main/kotlin/AgentEvents.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/AgentProvider.kt
+++ b/arc-agents/src/main/kotlin/AgentProvider.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/ChatAgent.kt
+++ b/arc-agents/src/main/kotlin/ChatAgent.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/DSLAgents.kt
+++ b/arc-agents/src/main/kotlin/DSLAgents.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/Exceptions.kt
+++ b/arc-agents/src/main/kotlin/Exceptions.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/LogContext.kt
+++ b/arc-agents/src/main/kotlin/LogContext.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/User.kt
+++ b/arc-agents/src/main/kotlin/User.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/conversation/Conversation.kt
+++ b/arc-agents/src/main/kotlin/conversation/Conversation.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/conversation/ConversationMessages.kt
+++ b/arc-agents/src/main/kotlin/conversation/ConversationMessages.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/AgentBuilder.kt
+++ b/arc-agents/src/main/kotlin/dsl/AgentBuilder.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/AgentDefinitionContext.kt
+++ b/arc-agents/src/main/kotlin/dsl/AgentDefinitionContext.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/AgentFactory.kt
+++ b/arc-agents/src/main/kotlin/dsl/AgentFactory.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/BeanProvider.kt
+++ b/arc-agents/src/main/kotlin/dsl/BeanProvider.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/DSLContext.kt
+++ b/arc-agents/src/main/kotlin/dsl/DSLContext.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/FilterContext.kt
+++ b/arc-agents/src/main/kotlin/dsl/FilterContext.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/FunctionDefinitionContext.kt
+++ b/arc-agents/src/main/kotlin/dsl/FunctionDefinitionContext.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/Tools.kt
+++ b/arc-agents/src/main/kotlin/dsl/Tools.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/extensions/Context.kt
+++ b/arc-agents/src/main/kotlin/dsl/extensions/Context.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/extensions/Events.kt
+++ b/arc-agents/src/main/kotlin/dsl/extensions/Events.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/extensions/Extract.kt
+++ b/arc-agents/src/main/kotlin/dsl/extensions/Extract.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/extensions/Files.kt
+++ b/arc-agents/src/main/kotlin/dsl/extensions/Files.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/extensions/Finish.kt
+++ b/arc-agents/src/main/kotlin/dsl/extensions/Finish.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/extensions/LLM.kt
+++ b/arc-agents/src/main/kotlin/dsl/extensions/LLM.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/extensions/Logging.kt
+++ b/arc-agents/src/main/kotlin/dsl/extensions/Logging.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/extensions/Memory.kt
+++ b/arc-agents/src/main/kotlin/dsl/extensions/Memory.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/extensions/Template.kt
+++ b/arc-agents/src/main/kotlin/dsl/extensions/Template.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/dsl/extensions/Times.kt
+++ b/arc-agents/src/main/kotlin/dsl/extensions/Times.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/events/EventListener.kt
+++ b/arc-agents/src/main/kotlin/events/EventListener.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/events/EventPublisher.kt
+++ b/arc-agents/src/main/kotlin/events/EventPublisher.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/events/Events.kt
+++ b/arc-agents/src/main/kotlin/events/Events.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/events/LoggingEventHandler.kt
+++ b/arc-agents/src/main/kotlin/events/LoggingEventHandler.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/events/MessagePublisher.kt
+++ b/arc-agents/src/main/kotlin/events/MessagePublisher.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/functions/FunctionEvents.kt
+++ b/arc-agents/src/main/kotlin/functions/FunctionEvents.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/functions/FunctionWithContext.kt
+++ b/arc-agents/src/main/kotlin/functions/FunctionWithContext.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/functions/Jsons.kt
+++ b/arc-agents/src/main/kotlin/functions/Jsons.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/functions/LLMFunction.kt
+++ b/arc-agents/src/main/kotlin/functions/LLMFunction.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/functions/LLMFunctionProvider.kt
+++ b/arc-agents/src/main/kotlin/functions/LLMFunctionProvider.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/functions/LambdaLLMFunction.kt
+++ b/arc-agents/src/main/kotlin/functions/LambdaLLMFunction.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/llm/ChatCompleter.kt
+++ b/arc-agents/src/main/kotlin/llm/ChatCompleter.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/llm/ChatCompleterProvider.kt
+++ b/arc-agents/src/main/kotlin/llm/ChatCompleterProvider.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/llm/ChatCompletionSettings.kt
+++ b/arc-agents/src/main/kotlin/llm/ChatCompletionSettings.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/llm/LLMEvents.kt
+++ b/arc-agents/src/main/kotlin/llm/LLMEvents.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/llm/Simularity.kt
+++ b/arc-agents/src/main/kotlin/llm/Simularity.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/llm/TextCompleterProvider.kt
+++ b/arc-agents/src/main/kotlin/llm/TextCompleterProvider.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/llm/TextEmbedder.kt
+++ b/arc-agents/src/main/kotlin/llm/TextEmbedder.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/memory/Memory.kt
+++ b/arc-agents/src/main/kotlin/memory/Memory.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/router/RouterEvents.kt
+++ b/arc-agents/src/main/kotlin/router/RouterEvents.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/main/kotlin/router/SemanticRouter.kt
+++ b/arc-agents/src/main/kotlin/router/SemanticRouter.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/ChatAgentTest.kt
+++ b/arc-agents/src/test/kotlin/ChatAgentTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/DSLAgentsTest.kt
+++ b/arc-agents/src/test/kotlin/DSLAgentsTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/TestBase.kt
+++ b/arc-agents/src/test/kotlin/TestBase.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/conversation/ConversationTest.kt
+++ b/arc-agents/src/test/kotlin/conversation/ConversationTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/dsl/AgentFilterTest.kt
+++ b/arc-agents/src/test/kotlin/dsl/AgentFilterTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/dsl/AgentSystemPromptTest.kt
+++ b/arc-agents/src/test/kotlin/dsl/AgentSystemPromptTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/dsl/AgentTest.kt
+++ b/arc-agents/src/test/kotlin/dsl/AgentTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/dsl/Filters.kt
+++ b/arc-agents/src/test/kotlin/dsl/Filters.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/dsl/FunctionsTest.kt
+++ b/arc-agents/src/test/kotlin/dsl/FunctionsTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/dsl/extensions/ExtractTest.kt
+++ b/arc-agents/src/test/kotlin/dsl/extensions/ExtractTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/dsl/extensions/FilesTest.kt
+++ b/arc-agents/src/test/kotlin/dsl/extensions/FilesTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/dsl/extensions/TemplateTest.kt
+++ b/arc-agents/src/test/kotlin/dsl/extensions/TemplateTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/events/BasicEventPublisherTest.kt
+++ b/arc-agents/src/test/kotlin/events/BasicEventPublisherTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/functions/JsonsTest.kt
+++ b/arc-agents/src/test/kotlin/functions/JsonsTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/functions/ParameterSchemaTest.kt
+++ b/arc-agents/src/test/kotlin/functions/ParameterSchemaTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/memory/InMemoryMemoryTest.kt
+++ b/arc-agents/src/test/kotlin/memory/InMemoryMemoryTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/kotlin/router/RouterTest.kt
+++ b/arc-agents/src/test/kotlin/router/RouterTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-agents/src/test/resources/test.txt
+++ b/arc-agents/src/test/resources/test.txt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 ARC is fun!

--- a/arc-api/build.gradle.kts
+++ b/arc-api/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-api/src/main/kotlin/AgentRequest.kt
+++ b/arc-api/src/main/kotlin/AgentRequest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-api/src/main/kotlin/AgentResult.kt
+++ b/arc-api/src/main/kotlin/AgentResult.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-api/src/main/kotlin/AnonymizationEntity.kt
+++ b/arc-api/src/main/kotlin/AnonymizationEntity.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-api/src/main/kotlin/Message.kt
+++ b/arc-api/src/main/kotlin/Message.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/README.md
+++ b/arc-assistants/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: CC0-1.0    
 -->

--- a/arc-assistants/build.gradle.kts
+++ b/arc-assistants/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/main/kotlin/ConversationClassifications.kt
+++ b/arc-assistants/src/main/kotlin/ConversationClassifications.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/main/kotlin/CustomerSupportAgent.kt
+++ b/arc-assistants/src/main/kotlin/CustomerSupportAgent.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 package org.eclipse.lmos.arc.assistants.support

--- a/arc-assistants/src/main/kotlin/extensions/LoadUseCases.kt
+++ b/arc-assistants/src/main/kotlin/extensions/LoadUseCases.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/main/kotlin/filters/LLMHackingDetector.kt
+++ b/arc-assistants/src/main/kotlin/filters/LLMHackingDetector.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/main/kotlin/filters/UnresolvedDetector.kt
+++ b/arc-assistants/src/main/kotlin/filters/UnresolvedDetector.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/main/kotlin/filters/UseCaseResponseHandler.kt
+++ b/arc-assistants/src/main/kotlin/filters/UseCaseResponseHandler.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/main/kotlin/usecases/UseCaseFormatter.kt
+++ b/arc-assistants/src/main/kotlin/usecases/UseCaseFormatter.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/main/kotlin/usecases/UseCaseIdExtractor.kt
+++ b/arc-assistants/src/main/kotlin/usecases/UseCaseIdExtractor.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/main/kotlin/usecases/UseCaseParser.kt
+++ b/arc-assistants/src/main/kotlin/usecases/UseCaseParser.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/test/kotlin/AlternativeSolutionFilterTest.kt
+++ b/arc-assistants/src/test/kotlin/AlternativeSolutionFilterTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/test/kotlin/ConditionsParserTest.kt
+++ b/arc-assistants/src/test/kotlin/ConditionsParserTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/test/kotlin/CustomerSupportAgentTest.kt
+++ b/arc-assistants/src/test/kotlin/CustomerSupportAgentTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/test/kotlin/TestBase.kt
+++ b/arc-assistants/src/test/kotlin/TestBase.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/test/kotlin/UseCaseIdExtractorTest.kt
+++ b/arc-assistants/src/test/kotlin/UseCaseIdExtractorTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/test/kotlin/UseCaseParserTest.kt
+++ b/arc-assistants/src/test/kotlin/UseCaseParserTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-assistants/src/test/resources/use_cases.md
+++ b/arc-assistants/src/test/resources/use_cases.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: CC0-1.0    
 -->

--- a/arc-assistants/src/test/resources/use_cases_mobile.md
+++ b/arc-assistants/src/test/resources/use_cases_mobile.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: CC0-1.0    
 -->

--- a/arc-assistants/src/test/resources/use_cases_out.md
+++ b/arc-assistants/src/test/resources/use_cases_out.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: CC0-1.0    
 -->

--- a/arc-azure-client/build.gradle.kts
+++ b/arc-azure-client/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-azure-client/src/main/kotlin/AzureAIClient.kt
+++ b/arc-azure-client/src/main/kotlin/AzureAIClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-azure-client/src/main/kotlin/AzureClientConfig.kt
+++ b/arc-azure-client/src/main/kotlin/AzureClientConfig.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-azure-client/src/main/kotlin/FunctionCallHandler.kt
+++ b/arc-azure-client/src/main/kotlin/FunctionCallHandler.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-azure-client/src/main/kotlin/LLMFunctionParamExtensions.kt
+++ b/arc-azure-client/src/main/kotlin/LLMFunctionParamExtensions.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-azure-client/src/test/kotlin/AzureAIClientTest.kt
+++ b/arc-azure-client/src/test/kotlin/AzureAIClientTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-azure-client/src/test/kotlin/AzureClientConfigTest.kt
+++ b/arc-azure-client/src/test/kotlin/AzureClientConfigTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-azure-client/src/test/kotlin/LLMFunctionParamExtensionsTest.kt
+++ b/arc-azure-client/src/test/kotlin/LLMFunctionParamExtensionsTest.kt
@@ -1,5 +1,5 @@
 
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-bom/build.gradle.kts
+++ b/arc-bom/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-gemini-client/build.gradle.kts
+++ b/arc-gemini-client/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-gemini-client/src/main/java/ai/ancf/lmos/arc/client/gemini/ByteMapper.java
+++ b/arc-gemini-client/src/main/java/ai/ancf/lmos/arc/client/gemini/ByteMapper.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-gemini-client/src/main/kotlin/FunctionCallHandler.kt
+++ b/arc-gemini-client/src/main/kotlin/FunctionCallHandler.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-gemini-client/src/main/kotlin/GeminiClient.kt
+++ b/arc-gemini-client/src/main/kotlin/GeminiClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-gemini-client/src/main/kotlin/GeminiClientConfig.kt
+++ b/arc-gemini-client/src/main/kotlin/GeminiClientConfig.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-gen/build.gradle.kts
+++ b/arc-gen/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-gen/src/main/kotlin/Agents.kt
+++ b/arc-gen/src/main/kotlin/Agents.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 @file:Suppress("ktlint")

--- a/arc-gen/src/main/kotlin/Functions.kt
+++ b/arc-gen/src/main/kotlin/Functions.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 @file:Suppress("ktlint")

--- a/arc-gradle-plugin/build.gradle.kts
+++ b/arc-gradle-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 import java.lang.System.getenv
 import java.net.URI
 
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-gradle-plugin/src/main/kotlin/ArcPlugin.kt
+++ b/arc-gradle-plugin/src/main/kotlin/ArcPlugin.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 package org.eclipse.lmos.arc.gradle.plugin

--- a/arc-gradle-plugin/src/main/kotlin/GenerateAgentCodeTask.kt
+++ b/arc-gradle-plugin/src/main/kotlin/GenerateAgentCodeTask.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-gradle-plugin/src/main/resources/AgentTemplate.kt.txt
+++ b/arc-gradle-plugin/src/main/resources/AgentTemplate.kt.txt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 @file:Suppress("ktlint")

--- a/arc-gradle-plugin/src/main/resources/FunctionTemplate.kt.txt
+++ b/arc-gradle-plugin/src/main/resources/FunctionTemplate.kt.txt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 @file:Suppress("ktlint")

--- a/arc-graphql-spring-boot-starter/build.gradle.kts
+++ b/arc-graphql-spring-boot-starter/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/main/kotlin/AgentResolver.kt
+++ b/arc-graphql-spring-boot-starter/src/main/kotlin/AgentResolver.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/main/kotlin/AutoConfiguration.kt
+++ b/arc-graphql-spring-boot-starter/src/main/kotlin/AutoConfiguration.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/main/kotlin/ContextHandler.kt
+++ b/arc-graphql-spring-boot-starter/src/main/kotlin/ContextHandler.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/main/kotlin/ErrorHandler.kt
+++ b/arc-graphql-spring-boot-starter/src/main/kotlin/ErrorHandler.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/main/kotlin/EventsConfiguration.kt
+++ b/arc-graphql-spring-boot-starter/src/main/kotlin/EventsConfiguration.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/main/kotlin/Logging.kt
+++ b/arc-graphql-spring-boot-starter/src/main/kotlin/Logging.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/main/kotlin/context/AnonymizationEntities.kt
+++ b/arc-graphql-spring-boot-starter/src/main/kotlin/context/AnonymizationEntities.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/main/kotlin/context/ContextProvider.kt
+++ b/arc-graphql-spring-boot-starter/src/main/kotlin/context/ContextProvider.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/main/kotlin/inbound/AgentQuery.kt
+++ b/arc-graphql-spring-boot-starter/src/main/kotlin/inbound/AgentQuery.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/main/kotlin/inbound/AgentSubscription.kt
+++ b/arc-graphql-spring-boot-starter/src/main/kotlin/inbound/AgentSubscription.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/main/kotlin/inbound/Converters.kt
+++ b/arc-graphql-spring-boot-starter/src/main/kotlin/inbound/Converters.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/main/kotlin/inbound/EventSubscription.kt
+++ b/arc-graphql-spring-boot-starter/src/main/kotlin/inbound/EventSubscription.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/arc-graphql-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 org.eclipse.lmos.arc.graphql.AgentGraphQLAutoConfiguration

--- a/arc-graphql-spring-boot-starter/src/main/resources/arc.properties
+++ b/arc-graphql-spring-boot-starter/src/main/resources/arc.properties
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/main/resources/chat/index.html
+++ b/arc-graphql-spring-boot-starter/src/main/resources/chat/index.html
@@ -1,5 +1,5 @@
 <!-- 
- SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
  SPDX-License-Identifier: Apache-2.0
 -->

--- a/arc-graphql-spring-boot-starter/src/test/kotlin/AgentEventsSubscriptionTest.kt
+++ b/arc-graphql-spring-boot-starter/src/test/kotlin/AgentEventsSubscriptionTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/test/kotlin/AgentSubscriptionTest.kt
+++ b/arc-graphql-spring-boot-starter/src/test/kotlin/AgentSubscriptionTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/test/kotlin/TestApplication.kt
+++ b/arc-graphql-spring-boot-starter/src/test/kotlin/TestApplication.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-graphql-spring-boot-starter/src/test/resources/application.yml
+++ b/arc-graphql-spring-boot-starter/src/test/resources/application.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/arc-langchain4j-client/build.gradle.kts
+++ b/arc-langchain4j-client/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-langchain4j-client/src/main/kotlin/FunctionCallHandler.kt
+++ b/arc-langchain4j-client/src/main/kotlin/FunctionCallHandler.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-langchain4j-client/src/main/kotlin/LangChainClient.kt
+++ b/arc-langchain4j-client/src/main/kotlin/LangChainClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-langchain4j-client/src/main/kotlin/LangChainConfig.kt
+++ b/arc-langchain4j-client/src/main/kotlin/LangChainConfig.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-langchain4j-client/src/main/kotlin/builders/BedrockBuilder.kt
+++ b/arc-langchain4j-client/src/main/kotlin/builders/BedrockBuilder.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-langchain4j-client/src/main/kotlin/builders/GeminiBuilder.kt
+++ b/arc-langchain4j-client/src/main/kotlin/builders/GeminiBuilder.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-langchain4j-client/src/main/kotlin/builders/GroqBuilder.kt
+++ b/arc-langchain4j-client/src/main/kotlin/builders/GroqBuilder.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-langchain4j-client/src/main/kotlin/builders/OllamaBuilder.kt
+++ b/arc-langchain4j-client/src/main/kotlin/builders/OllamaBuilder.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-langchain4j-client/src/test/kotlin/LangChainClientTest.kt
+++ b/arc-langchain4j-client/src/test/kotlin/LangChainClientTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-memory-mongo-spring-boot-starter/build.gradle.kts
+++ b/arc-memory-mongo-spring-boot-starter/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-memory-mongo-spring-boot-starter/src/main/kotlin/IndexCreator.kt
+++ b/arc-memory-mongo-spring-boot-starter/src/main/kotlin/IndexCreator.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-memory-mongo-spring-boot-starter/src/main/kotlin/MemoryAutoConfiguration.kt
+++ b/arc-memory-mongo-spring-boot-starter/src/main/kotlin/MemoryAutoConfiguration.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-memory-mongo-spring-boot-starter/src/main/kotlin/MemoryRepository.kt
+++ b/arc-memory-mongo-spring-boot-starter/src/main/kotlin/MemoryRepository.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-memory-mongo-spring-boot-starter/src/main/kotlin/MongoMemory.kt
+++ b/arc-memory-mongo-spring-boot-starter/src/main/kotlin/MongoMemory.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-memory-mongo-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/arc-memory-mongo-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 org.eclipse.lmos.arc.memory.mongo.MemoryAutoConfiguration

--- a/arc-memory-mongo-spring-boot-starter/src/test/kotlin/LongTermMemoryTest.kt
+++ b/arc-memory-mongo-spring-boot-starter/src/test/kotlin/LongTermMemoryTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 package org.eclipse.lmos.arc.memory.mongo

--- a/arc-memory-mongo-spring-boot-starter/src/test/kotlin/ShortTermMemoryTest.kt
+++ b/arc-memory-mongo-spring-boot-starter/src/test/kotlin/ShortTermMemoryTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 package org.eclipse.lmos.arc.memory.mongo

--- a/arc-memory-mongo-spring-boot-starter/src/test/kotlin/TestApplication.kt
+++ b/arc-memory-mongo-spring-boot-starter/src/test/kotlin/TestApplication.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-memory-mongo-spring-boot-starter/src/test/kotlin/TestBase.kt
+++ b/arc-memory-mongo-spring-boot-starter/src/test/kotlin/TestBase.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 package org.eclipse.lmos.arc.memory.mongo

--- a/arc-ollama-client/build.gradle.kts
+++ b/arc-ollama-client/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-ollama-client/src/main/kotlin/OllamaClient.kt
+++ b/arc-ollama-client/src/main/kotlin/OllamaClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-ollama-client/src/main/kotlin/OllamaClientConfig.kt
+++ b/arc-ollama-client/src/main/kotlin/OllamaClientConfig.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-ollama-client/src/main/resources/META-INF/native-image/io.github.lmos-ai.arc/arc-ollama-client/reflect-config.json.license
+++ b/arc-ollama-client/src/main/resources/META-INF/native-image/io.github.lmos-ai.arc/arc-ollama-client/reflect-config.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/arc-ollama-client/src/test/kotlin/OllamaClientConfigTest.kt
+++ b/arc-ollama-client/src/test/kotlin/OllamaClientConfigTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-ollama-client/src/test/kotlin/OllamaClientTest.kt
+++ b/arc-ollama-client/src/test/kotlin/OllamaClientTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-ollama-client/src/test/kotlin/TestBase.kt
+++ b/arc-ollama-client/src/test/kotlin/TestBase.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-openai-client/build.gradle.kts
+++ b/arc-openai-client/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-openai-client/src/main/kotlin/FunctionCallHandler.kt
+++ b/arc-openai-client/src/main/kotlin/FunctionCallHandler.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-openai-client/src/main/kotlin/OpenAILLMFunParamExtensions.kt
+++ b/arc-openai-client/src/main/kotlin/OpenAILLMFunParamExtensions.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-openai-client/src/main/kotlin/OpenAINativeClient.kt
+++ b/arc-openai-client/src/main/kotlin/OpenAINativeClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-openai-client/src/main/kotlin/OpenAINativeClientConfig.kt
+++ b/arc-openai-client/src/main/kotlin/OpenAINativeClientConfig.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-openai-client/src/test/kotlin/OpenAINativeClientConfigTest.kt
+++ b/arc-openai-client/src/test/kotlin/OpenAINativeClientConfigTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-openai-client/src/test/kotlin/OpenAINativeClientTest.kt
+++ b/arc-openai-client/src/test/kotlin/OpenAINativeClientTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-openai-client/src/test/kotlin/QuickRealTest.kt
+++ b/arc-openai-client/src/test/kotlin/QuickRealTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-reader-html/build.gradle.kts
+++ b/arc-reader-html/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-reader-html/src/main/kotlin/HtmlReader.kt
+++ b/arc-reader-html/src/main/kotlin/HtmlReader.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-reader-html/src/test/kotlin/HtmlReaderTest.kt
+++ b/arc-reader-html/src/test/kotlin/HtmlReaderTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-reader-html/src/test/resources/test.html
+++ b/arc-reader-html/src/test/resources/test.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/arc-reader-pdf/build.gradle.kts
+++ b/arc-reader-pdf/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-reader-pdf/src/main/kotlin/PdfReader.kt
+++ b/arc-reader-pdf/src/main/kotlin/PdfReader.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-reader-pdf/src/test/kotlin/PdfReaderTest.kt
+++ b/arc-reader-pdf/src/test/kotlin/PdfReaderTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-reader-pdf/src/test/resources/test.pdf.license
+++ b/arc-reader-pdf/src/test/resources/test.pdf.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/arc-result/build.gradle.kts
+++ b/arc-result/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-result/src/main/kotlin/Result.kt
+++ b/arc-result/src/main/kotlin/Result.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-result/src/test/kotlin/ResultTest.kt
+++ b/arc-result/src/test/kotlin/ResultTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/README.md
+++ b/arc-runner/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: CC0-1.0    
 -->

--- a/arc-runner/arc.java
+++ b/arc-runner/arc.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/arcPre.java
+++ b/arc-runner/arcPre.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/build.gradle.kts
+++ b/arc-runner/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/src/main/kotlin/Arc.kt
+++ b/arc-runner/src/main/kotlin/Arc.kt
@@ -1,4 +1,4 @@
-@file:JvmName("RunKt") // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+@file:JvmName("RunKt") // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/src/main/kotlin/Install.kt
+++ b/arc-runner/src/main/kotlin/Install.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/src/main/kotlin/List.kt
+++ b/arc-runner/src/main/kotlin/List.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/src/main/kotlin/NewAgent.kt
+++ b/arc-runner/src/main/kotlin/NewAgent.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/src/main/kotlin/NewFunction.kt
+++ b/arc-runner/src/main/kotlin/NewFunction.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/src/main/kotlin/Run.kt
+++ b/arc-runner/src/main/kotlin/Run.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/src/main/kotlin/Set.kt
+++ b/arc-runner/src/main/kotlin/Set.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/src/main/kotlin/Spring.kt
+++ b/arc-runner/src/main/kotlin/Spring.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/src/main/kotlin/View.kt
+++ b/arc-runner/src/main/kotlin/View.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/src/main/kotlin/server/Application.kt
+++ b/arc-runner/src/main/kotlin/server/Application.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/src/main/kotlin/server/ArcSetup.kt
+++ b/arc-runner/src/main/kotlin/server/ArcSetup.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/src/main/kotlin/server/ChatCompleterProvider.kt
+++ b/arc-runner/src/main/kotlin/server/ChatCompleterProvider.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 package org.eclipse.lmos.arc.runner.server

--- a/arc-runner/src/main/kotlin/server/Config.kt
+++ b/arc-runner/src/main/kotlin/server/Config.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/src/test/kotlin/RunTest.kt
+++ b/arc-runner/src/test/kotlin/RunTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-runner/weather.agent.kts
+++ b/arc-runner/weather.agent.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/build.gradle.kts
+++ b/arc-scripting/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/main/kotlin/DSLScriptAgents.kt
+++ b/arc-scripting/src/main/kotlin/DSLScriptAgents.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/main/kotlin/Exceptions.kt
+++ b/arc-scripting/src/main/kotlin/Exceptions.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/main/kotlin/ScriptHotReload.kt
+++ b/arc-scripting/src/main/kotlin/ScriptHotReload.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 package org.eclipse.lmos.arc.scripting

--- a/arc-scripting/src/main/kotlin/agents/AgentScriptEngine.kt
+++ b/arc-scripting/src/main/kotlin/agents/AgentScriptEngine.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/main/kotlin/agents/CompiledAgentLoader.kt
+++ b/arc-scripting/src/main/kotlin/agents/CompiledAgentLoader.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/main/kotlin/agents/Events.kt
+++ b/arc-scripting/src/main/kotlin/agents/Events.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/main/kotlin/agents/ScriptDef.kt
+++ b/arc-scripting/src/main/kotlin/agents/ScriptDef.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/main/kotlin/agents/ScriptingAgentLoader.kt
+++ b/arc-scripting/src/main/kotlin/agents/ScriptingAgentLoader.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/main/kotlin/functions/Events.kt
+++ b/arc-scripting/src/main/kotlin/functions/Events.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/main/kotlin/functions/FunctionScriptEngine.kt
+++ b/arc-scripting/src/main/kotlin/functions/FunctionScriptEngine.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/main/kotlin/functions/ScriptDef.kt
+++ b/arc-scripting/src/main/kotlin/functions/ScriptDef.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/main/kotlin/functions/ScriptingLLMFunctionLoader.kt
+++ b/arc-scripting/src/main/kotlin/functions/ScriptingLLMFunctionLoader.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/test/kotlin/AgentTest.kt
+++ b/arc-scripting/src/test/kotlin/AgentTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/test/kotlin/ContextTest.kt
+++ b/arc-scripting/src/test/kotlin/ContextTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/test/kotlin/DSLScriptAgentsTest.kt
+++ b/arc-scripting/src/test/kotlin/DSLScriptAgentsTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/test/kotlin/FunctionsTest.kt
+++ b/arc-scripting/src/test/kotlin/FunctionsTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/test/kotlin/HotReloadTest.kt
+++ b/arc-scripting/src/test/kotlin/HotReloadTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 package org.eclipse.lmos.arc.scripting

--- a/arc-scripting/src/test/kotlin/TestBase.kt
+++ b/arc-scripting/src/test/kotlin/TestBase.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/test/kotlin/Testing.kt
+++ b/arc-scripting/src/test/kotlin/Testing.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/test/kotlin/agents/ScriptingAgentLoaderTest.kt
+++ b/arc-scripting/src/test/kotlin/agents/ScriptingAgentLoaderTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/test/kotlin/functions/ScriptingLLMFunctionLoaderTest.kt
+++ b/arc-scripting/src/test/kotlin/functions/ScriptingLLMFunctionLoaderTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 package org.eclipse.lmos.arc.scripting.functions

--- a/arc-scripting/src/test/resources/kb-summarizer.agent.kts
+++ b/arc-scripting/src/test/resources/kb-summarizer.agent.kts
@@ -1,6 +1,6 @@
 import java.io.File
 
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/test/resources/knowledge-source.txt
+++ b/arc-scripting/src/test/resources/knowledge-source.txt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/test/resources/weather.agent.kts
+++ b/arc-scripting/src/test/resources/weather.agent.kts
@@ -1,5 +1,5 @@
 
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-scripting/src/test/resources/weather.functions.kts
+++ b/arc-scripting/src/test/resources/weather.functions.kts
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/arc-spring-ai/build.gradle.kts
+++ b/arc-spring-ai/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-ai/src/main/kotlin/Extensions.kt
+++ b/arc-spring-ai/src/main/kotlin/Extensions.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 package org.eclipse.lmos.arc.spring.ai

--- a/arc-spring-ai/src/main/kotlin/SpringChatClient.kt
+++ b/arc-spring-ai/src/main/kotlin/SpringChatClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 package org.eclipse.lmos.arc.spring.ai

--- a/arc-spring-ai/src/test/kotlin/SpringChatClientTest.kt
+++ b/arc-spring-ai/src/test/kotlin/SpringChatClientTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-ai/src/test/kotlin/TestApplication.kt
+++ b/arc-spring-ai/src/test/kotlin/TestApplication.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 package org.eclipse.lmos.arc.spring.ai

--- a/arc-spring-ai/src/test/kotlin/TestBase.kt
+++ b/arc-spring-ai/src/test/kotlin/TestBase.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/build.gradle.kts
+++ b/arc-spring-boot-starter/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/main/kotlin/AIConfig.kt
+++ b/arc-spring-boot-starter/src/main/kotlin/AIConfig.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/main/kotlin/Agents.kt
+++ b/arc-spring-boot-starter/src/main/kotlin/Agents.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/main/kotlin/ArcAutoConfiguration.kt
+++ b/arc-spring-boot-starter/src/main/kotlin/ArcAutoConfiguration.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/main/kotlin/ClientsConfiguration.kt
+++ b/arc-spring-boot-starter/src/main/kotlin/ClientsConfiguration.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/main/kotlin/CompiledScriptsConfiguration.kt
+++ b/arc-spring-boot-starter/src/main/kotlin/CompiledScriptsConfiguration.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/main/kotlin/Functions.kt
+++ b/arc-spring-boot-starter/src/main/kotlin/Functions.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/main/kotlin/Langchain4jConfiguration.kt
+++ b/arc-spring-boot-starter/src/main/kotlin/Langchain4jConfiguration.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/main/kotlin/MetricConfiguration.kt
+++ b/arc-spring-boot-starter/src/main/kotlin/MetricConfiguration.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/main/kotlin/MetricsHandler.kt
+++ b/arc-spring-boot-starter/src/main/kotlin/MetricsHandler.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 package org.eclipse.lmos.arc.spring

--- a/arc-spring-boot-starter/src/main/kotlin/ScriptingConfiguration.kt
+++ b/arc-spring-boot-starter/src/main/kotlin/ScriptingConfiguration.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/arc-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 org.eclipse.lmos.arc.spring.ArcAutoConfiguration

--- a/arc-spring-boot-starter/src/test/kotlin/AgentBeansTest.kt
+++ b/arc-spring-boot-starter/src/test/kotlin/AgentBeansTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/test/kotlin/AgentScriptTest.kt
+++ b/arc-spring-boot-starter/src/test/kotlin/AgentScriptTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/test/kotlin/GenAgentTest.kt
+++ b/arc-spring-boot-starter/src/test/kotlin/GenAgentTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/test/kotlin/TestApplication.kt
+++ b/arc-spring-boot-starter/src/test/kotlin/TestApplication.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/test/kotlin/TestEvent.kt
+++ b/arc-spring-boot-starter/src/test/kotlin/TestEvent.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/test/kotlin/gen/Agents.kt
+++ b/arc-spring-boot-starter/src/test/kotlin/gen/Agents.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 @file:Suppress("ktlint")

--- a/arc-spring-boot-starter/src/test/resources/agents/subfolder/travel.agent.kts
+++ b/arc-spring-boot-starter/src/test/resources/agents/subfolder/travel.agent.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/test/resources/agents/subfolder/travel.functions.kts
+++ b/arc-spring-boot-starter/src/test/resources/agents/subfolder/travel.functions.kts
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/arc-spring-boot-starter/src/test/resources/agents/weather.agent.kts
+++ b/arc-spring-boot-starter/src/test/resources/agents/weather.agent.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arc-spring-boot-starter/src/test/resources/agents/weather.functions.kts
+++ b/arc-spring-boot-starter/src/test/resources/agents/weather.functions.kts
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/arc-spring-boot-starter/src/test/resources/application.yml
+++ b/arc-spring-boot-starter/src/test/resources/application.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 arc:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-## SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+## SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 ##
 ## SPDX-License-Identifier: Apache-2.0
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Builds on top of https://github.com/eclipse-lmos/arc/pull/88.

See https://www.eclipse.org/projects/handbook/#ip-copyright-headers