### PR TITLE
Revert version to 0.1.0-SNAPHOST

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ org.gradle.dependency.verification=lenient
 #org.gradle.configuration-cache=true
 #org.gradle.configuration-cache.problems=warn
 org.gradle.configureondemand=true
-version=1.0.0-weekly-300125
+version=0.1.0-SNAPSHOT


### PR DESCRIPTION
@patwlan Please never ever change this version through commits manually - this [automatically publishes](https://github.com/eclipse-lmos/arc/actions/runs/13050887164/job/36433082078) the set version to Maven Central, which cannot be intended. We now e.g. also already have a published 0.2.0-SNAPSHOT, although this should not exist at all...

The `main` branch should always only build and publish the latest snapshot. As discussed with @pschwager, we will need release workflows that cover multiple repos at once, create a tag with the released version and publish it from there.