### PR TITLE
Use lmos snapshot version of arc-runner when running it via jbang

### DIFF
--- a/arc-runner/arc.java
+++ b/arc-runner/arc.java
@@ -7,14 +7,15 @@
 
 //COMPILE_OPTIONS -Xlint:-options
 
-//DEPS ai.ancf.lmos:arc-runner:0.107.0
+//REPOS mavencentral,snapshots=https://oss.sonatype.org/content/repositories/snapshots/
+//DEPS org.eclipse.lmos:arc-runner:0.1.0-SNAPSHOT
 //DEPS org.slf4j:slf4j-api:2.0.16
 //DEPS com.fasterxml.jackson.core:jackson-databind:2.17.2
 //DEPS io.projectreactor:reactor-core:3.6.9
 
 package arc.runner;
 
-import ai.ancf.lmos.arc.runner.Arc;
+import org.eclipse.lmos.arc.runner.Arc;
 import picocli.CommandLine;
 
 /* ktlint-disable */

--- a/arc-runner/build.gradle.kts
+++ b/arc-runner/build.gradle.kts
@@ -5,7 +5,7 @@
 dependencies {
     val ktorVersion = "3.1.0"
     val langchain4jVersion = "0.36.2"
-    val graphqlKotlinVersion = "8.2.1"
+    val graphqlKotlinVersion = "8.3.0"
     val logbackVersion = "1.5.16"
 
     implementation(project(":arc-agents"))
@@ -38,6 +38,11 @@ dependencies {
     // Ktor
     implementation("io.ktor:ktor-server-core-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
+    implementation("io.ktor:ktor-server-websockets:$ktorVersion")
+    implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")
+    implementation("io.ktor:ktor-server-cors:$ktorVersion")
     implementation("ch.qos.logback:logback-classic:$logbackVersion")
 
     // Tests

--- a/arc-runner/src/main/kotlin/Arc.kt
+++ b/arc-runner/src/main/kotlin/Arc.kt
@@ -5,6 +5,7 @@
 
 package org.eclipse.lmos.arc.runner
 
+import picocli.CommandLine
 import picocli.CommandLine.Command
 import java.io.File
 import java.io.FileInputStream
@@ -47,4 +48,11 @@ fun loadProperties(): Properties {
 fun Properties.storeInHome() {
     val propertiesFile = File(home(), "arc.properties")
     FileOutputStream(propertiesFile).use { store(it, null) }
+}
+
+/**
+ * Main method for running the arc runner without jbang, e.g., from IDE.
+ */
+fun main(args: Array<String>) {
+    CommandLine(Arc()).execute(*args)
 }

--- a/arc-runner/src/main/kotlin/Run.kt
+++ b/arc-runner/src/main/kotlin/Run.kt
@@ -26,7 +26,7 @@ class RunArc : Runnable {
     private var agentFolder: String = ""
 
     override fun run() {
-        println("Staring Arc Runner...")
+        println("Starting Arc Runner...")
 
         val properties = loadProperties()
 

--- a/arc-runner/src/main/kotlin/View.kt
+++ b/arc-runner/src/main/kotlin/View.kt
@@ -25,7 +25,7 @@ open class OpenView : Runnable {
     override fun run() {
         println("Opening Arc View...")
         try {
-            Desktop.getDesktop().browse(URI("http://localhost:$port/chat/index.html"))
+            Desktop.getDesktop().browse(URI("https://eclipse.dev/lmos/chat/index.html?agentUrl=http://localhost:$port#/chat"))
         } catch (e: Exception) {
             e.printStackTrace()
         }

--- a/arc-runner/src/main/kotlin/server/Application.kt
+++ b/arc-runner/src/main/kotlin/server/Application.kt
@@ -8,18 +8,20 @@ import com.expediagroup.graphql.server.ktor.GraphQL
 import com.expediagroup.graphql.server.ktor.defaultGraphQLStatusPages
 import com.expediagroup.graphql.server.ktor.graphQLPostRoute
 import com.expediagroup.graphql.server.ktor.graphQLSubscriptionsRoute
+import io.ktor.http.*
 import io.ktor.serialization.jackson.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.http.content.*
 import io.ktor.server.netty.*
+import io.ktor.server.plugins.cors.routing.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
 import org.eclipse.lmos.arc.graphql.inbound.AgentQuery
 import org.eclipse.lmos.arc.graphql.inbound.AgentSubscription
 import org.eclipse.lmos.arc.graphql.inbound.EventSubscription
-import java.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Starts the ARC server.
@@ -46,14 +48,22 @@ fun runApp(appConfig: AppConfig) {
         }
 
         install(WebSockets) {
-            pingPeriod = Duration.ofSeconds(1)
+            pingPeriod = 1.seconds
             contentConverter = JacksonWebsocketContentConverter()
         }
 
         install(RoutingRoot) {
-            staticResources("/chat", "/chat")
             graphQLPostRoute()
             graphQLSubscriptionsRoute()
+        }
+
+        install(CORS) {
+            anyHost()
+            allowHeader(HttpHeaders.ContentType)
+            allowHeader(HttpHeaders.Authorization)
+            allowMethod(HttpMethod.Get)
+            allowMethod(HttpMethod.Post)
+            allowMethod(HttpMethod.Put)
         }
     }.start(wait = true)
 }


### PR DESCRIPTION
Switches to use org.eclipse.lmos:arc-runner:0.1.0-SNAPSHOT (instead of ai.ancf.lmos:arc-runner:0.107.0) in the arc runner.

To make this work, a few adaptations are made:
* Fix issues that popped up due to the ktor version upgrade (in particular, in the interplay with ktor-graphql)
* Open the hosted version of the arc-view (since the arc-view is no longer packaged with the arc-spring-boot-starter)
* Permit all CORS origins, so that local agents can be called from the hosted version of the arc-view

@patwlan Not sure if this is what you intended when you brought this topic up on Discord (in particular regarding from where to load the arc-view), but we can have a chat on that when you have time or discuss here on github - I open this PR already as basis for discussion.