### PR TITLE
Add SBOM generation and upload to DependencyTrack workflow

### DIFF
--- a/.github/workflows/generate-gradle-sbom.yml
+++ b/.github/workflows/generate-gradle-sbom.yml
@@ -1,0 +1,70 @@
+name: Generate Gradle SBOM
+
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        default: 'main'
+        required: true
+
+env:
+  JAVA_VERSION: '21'
+  JAVA_DISTRO: 'temurin'
+  PRODUCT_PATH: './'
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      project-version: ${{ steps.version.outputs.PROJECT_VERSION }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.version }}
+
+      - name: Setup Java SDK
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
+
+      - name: Generate sbom
+        run: |
+          gradle cyclonedxBom
+
+      - name: Extract product version
+        id: version
+        shell: bash
+        run: |
+          VERSION="$(jq -r '.metadata.component.version' < ./${{ env.PRODUCT_PATH }}build/reports/bom.json)"
+          echo "PROJECT_VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Product version is: $VERSION"
+
+      - name: Upload sbom
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: sbom
+          path: ${{ env.PRODUCT_PATH }}build/reports/bom.json
+
+  store-sbom-data: # stores sbom and metadata in a predefined format for otterdog to pick up
+    needs: ['generate-sbom']
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: 'arc'
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: 'sbom'
+      bomFilename: 'bom.json'
+      parentProject: 'a75a955e-abd4-4908-b2c4-08a517b63af8'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,11 +9,14 @@ import java.io.InputStreamReader
 import java.lang.System.getenv
 import java.net.URI
 
+group = "org.eclipse.lmos"
+version = project.findProperty("version") as String
+
 plugins {
     kotlin("jvm") version "2.1.10" apply false
     kotlin("plugin.serialization") version "2.1.10" apply false
     id("org.jetbrains.dokka") version "2.0.0"
-    id("org.cyclonedx.bom") version "2.0.0" apply false
+    id("org.cyclonedx.bom") version "2.0.0"
     id("org.jlleitschuh.gradle.ktlint") version "12.2.0"
     id("org.jetbrains.kotlinx.kover") version "0.9.1"
     id("net.researchgate.release") version "3.1.0"
@@ -23,7 +26,6 @@ plugins {
 subprojects {
     group = "org.eclipse.lmos"
 
-    apply(plugin = "org.cyclonedx.bom")
     apply(plugin = "org.jetbrains.dokka")
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "kotlinx-serialization")


### PR DESCRIPTION
As previously discussed, this PR aims to bootstrap the EF Security Team initiative of implementing automated SBOM generation for projects and uploading them to our DependencyTrack instance, with the goal of enhancing software supply chain security.

To summarise, the workflow is currently triggered by the successful completion of the "Release" workflow. A gradle cyclonedx plugin is then used to generate 1 SBOM for the entire arc product, which is then uploaded as an artifact. The "store-sbom-data" reusable workflow stores additional metadata about the project and upon completion, the self service system (otterdog) downloads the SBOM from artifacts and uploads it to our DependencyTrack instance (sbom.eclipse.org).

Some implementation decisions worth mentioning:

1. `workflow_run` trigger instead of push to deps file/new tags: 

**Reasoning**: The product has multiple internal submodules listed as dependencies. When a new release is created, the version is updated for submodules as well, which are then pushed to an external location (for example: maven central). SBOM generation tooling needs to be able to pull the new dependencies versions from this location, hence requiring a delay.

2. Changes to `build.gradle.kts`

-  Adding `group` and `version`
**Reasoning:** Required by the cyclonedx gradle plugin to be specified in the `build.gradle.kts` file, otherwise the generation task fails.
- Removing `apply false` and `apply` per submodule
**Reasoning:** The plugin was only referenced (per submodule) but not used up until now and as earlier discussed, sticking to generating 1 big SBOM for the entire repo, as opposed to 1 SBOM per submodule, which would be more difficult to manage.

**Note**: We usually try to avoid touching other project files apart from the new SBOM workflow, however the cyclonedx gradle plugin required the changes above. 

We have limited permissions, hence e2e testing is difficult, but we were able to test that the SBOM generation and upload to DependencyTrack work as expected. However due to limited knowledge of the project and ecosystem, we **cannot guarantee** the changes to `build.gradle.kts` listed above won't break some of your other existing workflows. Please make sure to thoroughly check these as well. Edits by maintainers are enabled, so feel free to adapt them as you see fit.