### PR TITLE
fix: trim use case id response

### DIFF
--- a/arc-assistants/src/main/kotlin/usecases/UseCaseIdExtractor.kt
+++ b/arc-assistants/src/main/kotlin/usecases/UseCaseIdExtractor.kt
@@ -13,7 +13,7 @@ typealias UseCaseId = String
 private val useCaseIdRegex = "<ID:(.*)>".toRegex()
 
 fun extractUseCaseId(message: String): Pair<String, UseCaseId?> {
-    val id = useCaseIdRegex.find(message)?.groupValues?.elementAtOrNull(1)
+    val id = useCaseIdRegex.find(message)?.groupValues?.elementAtOrNull(1)?.trim()
     val cleanedMessage = message.replace(useCaseIdRegex, "").trim()
     return cleanedMessage to id
 }


### PR DESCRIPTION
Fix for Bug::
LLM sometimes appends space( ) in response when providing usecase id
Ex: <ID: usecaseId> messageContent
This extra space creates issue when id is checked later. So trimming the 'id' while extracting it