### PR TITLE
fix: Use lazy matching for usecase id regex match

### DIFF
--- a/arc-assistants/src/main/kotlin/usecases/UseCaseIdExtractor.kt
+++ b/arc-assistants/src/main/kotlin/usecases/UseCaseIdExtractor.kt
@@ -10,7 +10,7 @@ typealias UseCaseId = String
  * Extract the use case id from the assistant message.
  * For example, "<ID:useCaseId>"
  */
-private val useCaseIdRegex = "<ID:(.*)>".toRegex()
+private val useCaseIdRegex = "<ID:(.*?)>".toRegex()
 
 fun extractUseCaseId(message: String): Pair<String, UseCaseId?> {
     val id = useCaseIdRegex.find(message)?.groupValues?.elementAtOrNull(1)?.trim()

--- a/arc-assistants/src/test/kotlin/usecases/UseCaseIdExtractorTest.kt
+++ b/arc-assistants/src/test/kotlin/usecases/UseCaseIdExtractorTest.kt
@@ -57,4 +57,13 @@ class UseCaseIdExtractorTest {
         val (_, stepId) = extractUseCaseStepId(message)
         assertThat(stepId).isNull()
     }
+
+    @Test
+    fun `test use case id extraction contains closing bracket`(): Unit = runBlocking {
+        val message = """<ID:use_case01>
+                 This is a reply from the LLM with <Dummy Data>"""
+        val (filteredMessage, useCaseId) = extractUseCaseId(message)
+        assertThat(filteredMessage).contains("This is a reply from the LLM with <Dummy Data>")
+        assertThat(useCaseId).isEqualTo("use_case01")
+    }
 }


### PR DESCRIPTION
Current usecase id regex uses greedy match. For ex: 
<ID:test> This is llm response with <some data> in it
Gives usecase ID: test> This is llm response with <some data

Which is incorrect. This PR fixes this issue
