### PR TITLE
fix(logging): Log agent request with correct context

### DIFF
--- a/arc-graphql-spring-boot-starter/src/main/kotlin/inbound/AgentSubscription.kt
+++ b/arc-graphql-spring-boot-starter/src/main/kotlin/inbound/AgentSubscription.kt
@@ -64,9 +64,9 @@ class AgentSubscription(
             }
 
             val result = withLogContext(agent.name, request) {
-                log.info("Received request: ${request.systemContext}")
 
                 combinedContextHandler.inject(request) { extraContext ->
+                    log.info("Received request: ${request.systemContext}")
                     agent.executeWithHandover(
                         Conversation(
                             user = request.userContext.userId?.let { User(it) },


### PR DESCRIPTION
The log was out of final context and hence some fields didn't have correct values reflected.