### PR TITLE
fix(GeminiClientLoader): update builder import to use geminiBuilder

### DIFF
--- a/arc-langchain4j-client/src/main/kotlin/loaders/GeminiClientLoader.kt
+++ b/arc-langchain4j-client/src/main/kotlin/loaders/GeminiClientLoader.kt
@@ -8,7 +8,7 @@ import org.eclipse.lmos.arc.agents.llm.AIClientConfig
 import org.eclipse.lmos.arc.agents.llm.ANY_MODEL
 import org.eclipse.lmos.arc.agents.tracing.AgentTracer
 import org.eclipse.lmos.arc.client.langchain4j.LangChainClient
-import org.eclipse.lmos.arc.client.langchain4j.builders.ollamaBuilder
+import org.eclipse.lmos.arc.client.langchain4j.builders.geminiBuilder
 
 class GeminiClientLoader : ClientLoader(
     name = "GEMINI",
@@ -22,7 +22,7 @@ class GeminiClientLoader : ClientLoader(
         eventPublisher: EventPublisher?,
     ) = buildMap {
         config.apiKey ?: error("API key is required for Gemini!")
-        val client = LangChainClient(config, ollamaBuilder(), eventPublisher, tracer)
+        val client = LangChainClient(config, geminiBuilder(), eventPublisher, tracer)
         put(config.modelAlias ?: config.modelName ?: ANY_MODEL, client)
     }
 }


### PR DESCRIPTION
### Problem
The current `GeminiClientLoader` structure in the `arc` project does not correctly support Gemini models — it incorrectly identifies them as Ollama models.

### Solution
This PR overrides the `GeminiClientLoader` and uses the appropriate builder for Gemini models to ensure proper integration.

### Testing
The changes were tested locally within the Eclipse LMOS environment using Gemini models. The integration worked as expected without any issues.
