### PR TITLE
feat(core): add tool calls to generated Assistant messages.

### DIFF
--- a/arc-agents/src/main/kotlin/conversation/ConversationMessages.kt
+++ b/arc-agents/src/main/kotlin/conversation/ConversationMessages.kt
@@ -101,11 +101,18 @@ data class AssistantMessage(
     override val anonymized: Boolean = false,
     override val binaryData: List<BinaryData> = emptyList(),
     override val format: MessageFormat = MessageFormat.TEXT,
+    val toolCalls: List<ToolCall>? = null,
     val userTranscript: String? = null,
 ) : ConversationMessage() {
     override fun applyTurn(turnId: String): AssistantMessage = copy(turnId = turnId)
     override fun update(content: String): AssistantMessage = copy(content = content)
 }
+
+/**
+ * Represents a tool call made by the LLM Model.
+ */
+@Serializable
+data class ToolCall(val name: String)
 
 /**
  * A message sent by the Developer.

--- a/arc-agents/src/main/kotlin/dsl/extensions/Files.kt
+++ b/arc-agents/src/main/kotlin/dsl/extensions/Files.kt
@@ -5,7 +5,6 @@
 package org.eclipse.lmos.arc.agents.dsl.extensions
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch

--- a/arc-api/src/main/kotlin/AgentResult.kt
+++ b/arc-api/src/main/kotlin/AgentResult.kt
@@ -16,7 +16,14 @@ data class AgentResult(
     val messages: List<Message>,
     val anonymizationEntities: List<AnonymizationEntity>? = null,
     val context: List<ContextEntry>? = null,
+    val toolCalls: List<ToolCall>? = null,
 )
+
+/**
+ * Represents a tool call made by the LLM Model.
+ */
+@Serializable
+data class ToolCall(val name: String)
 
 /**
  * Context contain entries that were added during the processing of the request.

--- a/arc-azure-client/src/main/kotlin/AzureAIClient.kt
+++ b/arc-azure-client/src/main/kotlin/AzureAIClient.kt
@@ -24,6 +24,7 @@ import org.eclipse.lmos.arc.agents.conversation.AssistantMessage
 import org.eclipse.lmos.arc.agents.conversation.ConversationMessage
 import org.eclipse.lmos.arc.agents.conversation.MessageFormat
 import org.eclipse.lmos.arc.agents.conversation.SystemMessage
+import org.eclipse.lmos.arc.agents.conversation.ToolCall
 import org.eclipse.lmos.arc.agents.conversation.UserMessage
 import org.eclipse.lmos.arc.agents.events.EventPublisher
 import org.eclipse.lmos.arc.agents.functions.LLMFunction
@@ -93,6 +94,7 @@ class AzureAIClient(
     private fun ChatCompletions.getFirstAssistantMessage(
         sensitive: Boolean = false,
         settings: ChatCompletionSettings?,
+        toolCalls: Map<String, LLMFunction>,
     ) = choices.first().message.content.let {
         AssistantMessage(
             it ?: "",
@@ -101,6 +103,7 @@ class AzureAIClient(
                 JSON -> MessageFormat.JSON
                 else -> MessageFormat.TEXT
             },
+            toolCalls = toolCalls.map { ToolCall(it.key) },
         )
     }
 
@@ -128,6 +131,7 @@ class AzureAIClient(
                 it.getFirstAssistantMessage(
                     sensitive = functionCallHandler.calledSensitiveFunction(),
                     settings = settings,
+                    toolCalls = functionCallHandler.calledFunctions,
                 )
             }
         }

--- a/arc-azure-client/src/main/kotlin/OpenInferenceTags.kt
+++ b/arc-azure-client/src/main/kotlin/OpenInferenceTags.kt
@@ -86,7 +86,7 @@ object OpenInferenceTags {
                 "llm.tools.$i.tool.json_schema",
                 """{"type":"function","function":{"name":"${tool.name}","parameters":${tool.parameters.toJsonString()},"description":"${tool.description}"}}""".replace(
                     "\n",
-                    " "
+                    " ",
                 ),
             )
         }
@@ -121,7 +121,7 @@ object OpenInferenceTags {
             "tool.json_schema",
             """{"type":"function","function":{"name":"${function.name}","parameters":${function.parameters.toJsonString()},"description":"${function.description}"}}""".replace(
                 "\n",
-                " "
+                " ",
             ),
         )
     }

--- a/arc-langchain4j-client/src/main/kotlin/LangChainClient.kt
+++ b/arc-langchain4j-client/src/main/kotlin/LangChainClient.kt
@@ -28,6 +28,7 @@ import org.eclipse.lmos.arc.agents.conversation.AssistantMessage
 import org.eclipse.lmos.arc.agents.conversation.BinaryData
 import org.eclipse.lmos.arc.agents.conversation.ConversationMessage
 import org.eclipse.lmos.arc.agents.conversation.SystemMessage
+import org.eclipse.lmos.arc.agents.conversation.ToolCall
 import org.eclipse.lmos.arc.agents.conversation.UserMessage
 import org.eclipse.lmos.arc.agents.events.EventPublisher
 import org.eclipse.lmos.arc.agents.functions.LLMFunction
@@ -102,6 +103,7 @@ class LangChainClient(
                         val output = AssistantMessage(
                             response!!.content().text() ?: "",
                             sensitive = functionCallHandler.calledSensitiveFunction(),
+                            toolCalls = functionCallHandler.calledFunctions.map { ToolCall(it.key) },
                         )
                         tags.addLLMTags(
                             config,

--- a/arc-scripting/src/main/kotlin/agents/ScriptingAgentLoader.kt
+++ b/arc-scripting/src/main/kotlin/agents/ScriptingAgentLoader.kt
@@ -44,7 +44,6 @@ class ScriptingAgentLoader(
         val result = agentScriptEngine.eval(agentScript, context)
         if (result is Success && context.agents.isNotEmpty()) {
             log.info("Discovered the following agents (scripting): ${context.agents.joinToString { it.name }}")
-            agents.clear()
             agents.putAll(context.agents.associateBy { it.name })
         }
         return result
@@ -55,7 +54,6 @@ class ScriptingAgentLoader(
         compiledAgentScript.load(context)
         if (context.agents.isNotEmpty()) {
             log.info("Discovered the following agents (scripting): ${context.agents.joinToString { it.name }}")
-            agents.clear()
             agents.putAll(context.agents.associateBy { it.name })
         }
     }


### PR DESCRIPTION
Adds the list of tools that the LLM used to generate the assistant message. 
Currently, only the name will be returned, but in the future more details may be returned.