### PR TITLE
fix(ScriptingAgentLoader): clear agents before loading new ones

### DIFF
--- a/arc-scripting/src/main/kotlin/agents/ScriptingAgentLoader.kt
+++ b/arc-scripting/src/main/kotlin/agents/ScriptingAgentLoader.kt
@@ -44,6 +44,7 @@ class ScriptingAgentLoader(
         val result = agentScriptEngine.eval(agentScript, context)
         if (result is Success && context.agents.isNotEmpty()) {
             log.info("Discovered the following agents (scripting): ${context.agents.joinToString { it.name }}")
+            agents.clear()
             agents.putAll(context.agents.associateBy { it.name })
         }
         return result
@@ -54,6 +55,7 @@ class ScriptingAgentLoader(
         compiledAgentScript.load(context)
         if (context.agents.isNotEmpty()) {
             log.info("Discovered the following agents (scripting): ${context.agents.joinToString { it.name }}")
+            agents.clear()
             agents.putAll(context.agents.associateBy { it.name })
         }
     }


### PR DESCRIPTION
**Problem**
When using Arc runner with hot-deploy, renaming an agent in the DSL (without changing the script filename) causes both the old and new agent names to appear after a browser refresh. The old agent is not removed from the registry, leading old ones still visible.

**Solution**
This PR updates the agent loading logic to ensure that the agent registry is cleared before adding agents from the latest DSL script. Now, only agents defined in the current script are present after a hot-deploy, and any agents with old names are properly removed.

**Note**: It addresses #29 