### PR TITLE
feat(agents): add more details to the ToolCalls object.

### DIFF
--- a/arc-agents/src/main/kotlin/conversation/Adapters.kt
+++ b/arc-agents/src/main/kotlin/conversation/Adapters.kt
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.eclipse.lmos.arc.agents.conversation
+
+import org.eclipse.lmos.arc.agents.llm.LLMToolCall
+
+/**
+ * Converts an LLMToolCall to a ToolCall.
+ *
+ * @receiver LLMToolCall to be converted.
+ * @return ToolCall representation of the LLMToolCall.
+ */
+fun LLMToolCall.toToolCall(): ToolCall {
+    return ToolCall(name = tool.name, arguments = argumentsJson, failed = failed?.message)
+}

--- a/arc-agents/src/main/kotlin/llm/LLMToolCall.kt
+++ b/arc-agents/src/main/kotlin/llm/LLMToolCall.kt
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.eclipse.lmos.arc.agents.llm
+
+import org.eclipse.lmos.arc.agents.functions.LLMFunction
+
+/**
+ * Represents a tool call made by an LLM.
+ *
+ * @property tool The LLM function being called.
+ * @property arguments The arguments passed to the function.
+ * @property failed Indicates whether the tool call failed.
+ */
+data class LLMToolCall(
+    val tool: LLMFunction,
+    val arguments: Map<String, Any?>,
+    val argumentsJson: String,
+    val failed: Exception? = null,
+)


### PR DESCRIPTION
The goal of this PR is to add more information to the recently introduced ToolCalls objects.

The ToolCalls object is passed to the client as part of the overall response.
Its main purpose is to better debug the inner workings of agents.