### PR TITLE
DSL: Sequential and session-related execution limits for use cases

### DIFF
--- a/arc-assistants/src/main/kotlin/extensions/LoadUseCases.kt
+++ b/arc-assistants/src/main/kotlin/extensions/LoadUseCases.kt
@@ -52,10 +52,7 @@ suspend fun DSLContext.useCases(
 
         val usedUseCases = memory("usedUseCases") as List<String>? ?: emptyList()
         val useCaseMap = useCases.associateBy { it.id }
-        val fallbackCases = usedUseCases.groupingBy { it }.eachCount().filter { (id, count) ->
-            val execLimit = useCaseMap[id]?.executionLimit ?: fallbackLimit
-            count >= execLimit
-        }.keys
+        val fallbackCases = getFallbackCases(usedUseCases, useCases, fallbackLimit)
         val filteredUseCases = useCases.filter(filter)
         val formattedUseCases =
             filteredUseCases.formatToString(
@@ -87,6 +84,51 @@ suspend fun DSLContext.useCases(
     }
 }
 
+/**
+ * Determines which use case IDs should be considered as fallback cases
+ * based on their usage history and defined limits.
+ *
+ * There are two criteria for a use case to be a fallback:
+ * 1. Fallback Limit: If the total number of occurrences of a use case ID
+ *    in `usedUseCases` is greater than or equal to `fallbackLimit`, regardless of order.
+ * 2. Execution Limit: If the maximum number of consecutive occurrences (streak)
+ *    of a use case ID in `usedUseCases` is greater than or equal to its `executionLimit`.
+ *    If `executionLimit` is not set, `fallbackLimit` is used as the default.
+ *
+ * @param usedUseCases List of use case IDs that have already been used.
+ * @param useCases List of defined use cases, each with an optional `executionLimit`.
+ * @param fallbackLimit The default limit for the number of occurrences to consider a use case as fallback.
+ * @return A set of use case IDs that meet at least one of the fallback criteria.
+ */
+fun getFallbackCases(
+    usedUseCases: List<String>,
+    useCases: List<UseCase>,
+    fallbackLimit: Int
+): Set<String> {
+    val useCaseMap = useCases.associateBy { it.id }
+    val fallbackCases = usedUseCases.groupingBy { it }.eachCount().filter { (id, count) ->
+        val execLimit = useCaseMap[id]?.executionLimit ?: fallbackLimit
+        count >= fallbackLimit
+    }.keys.toMutableSet()
+
+    useCases.forEach { useCase ->
+        val execLimit = useCase.executionLimit ?: fallbackLimit
+        var maxStreak = 0
+        var currentStreak = 0
+        usedUseCases.forEach { id ->
+            if (id == useCase.id) {
+                currentStreak++
+                if (currentStreak > maxStreak) maxStreak = currentStreak
+            } else {
+                currentStreak = 0
+            }
+        }
+        if (maxStreak >= execLimit) {
+            fallbackCases.add(useCase.id)
+        }
+    }
+    return fallbackCases
+}
 /**
  * Extension function to format a list of use cases into a string representation.
  *

--- a/arc-assistants/src/main/kotlin/extensions/LoadUseCases.kt
+++ b/arc-assistants/src/main/kotlin/extensions/LoadUseCases.kt
@@ -148,12 +148,7 @@ suspend fun DSLContext.processUseCases(
     formatter: suspend (String, UseCase, List<UseCase>?, List<String>) -> String = { s, _, _, _ -> s },
 ): String {
     val usedUseCases = memory("usedUseCases") as List<String>? ?: emptyList()
-    val fallbackCases =
-        usedUseCases
-            .groupingBy { it }
-            .eachCount()
-            .filter { it.value >= fallbackLimit }
-            .keys
+    val fallbackCases = getFallbackCases(usedUseCases, useCases, fallbackLimit)
     val filteredUseCases =
         useCases.formatToString(
             usedUseCases.toSet(),

--- a/arc-assistants/src/test/kotlin/extensions/LoadUseCasesTest.kt
+++ b/arc-assistants/src/test/kotlin/extensions/LoadUseCasesTest.kt
@@ -7,11 +7,13 @@ package org.eclipse.lmos.arc.assistants.support.extensions
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.lmos.arc.agents.conversation.Conversation
+import org.eclipse.lmos.arc.agents.dsl.extensions.getFallbackCases
 import org.eclipse.lmos.arc.agents.dsl.extensions.useCases
 import org.eclipse.lmos.arc.agents.dsl.withDSLContext
 import org.eclipse.lmos.arc.agents.memory.InMemoryMemory
 import org.eclipse.lmos.arc.assistants.support.TestBase
 import org.eclipse.lmos.arc.assistants.support.usecases.OutputOptions
+import org.eclipse.lmos.arc.assistants.support.usecases.UseCase
 import org.junit.jupiter.api.Test
 
 class LoadUseCasesTest : TestBase() {
@@ -95,5 +97,43 @@ class LoadUseCasesTest : TestBase() {
                 """.trimIndent().trim(),
             )
         }
+    }
+
+}
+
+class GetFallbackCasesTest {
+
+    @Test
+    fun `executionLimit positive - streak reached`() {
+        val useCases = listOf(UseCase(id = "A", executionLimit = 3))
+        val used = listOf("A", "A", "A", "B", "C")
+        val result = getFallbackCases(used, useCases, fallbackLimit = 5)
+        assert(result.contains("A"))
+    }
+
+    @Test
+    fun `executionLimit negative - streak not reached`() {
+        val useCases = listOf(UseCase(id = "A", executionLimit = 3))
+        val used = listOf("A", "B", "A", "A", "C")
+        val result = getFallbackCases(used, useCases, fallbackLimit = 5)
+        assert(!result.contains("A"))
+        assert(!result.contains("B"))
+        assert(!result.contains("C"))
+    }
+
+    @Test
+    fun `fallbackLimit positive - count reached`() {
+        val useCases = listOf(UseCase(id = "B"))
+        val used = listOf("B", "A", "B", "C", "B", "B")
+        val result = getFallbackCases(used, useCases, fallbackLimit = 4)
+        assert(result.contains("B"))
+    }
+
+    @Test
+    fun `fallbackLimit negative - count not reached`() {
+        val useCases = listOf(UseCase(id = "B"))
+        val used = listOf("B", "A", "B", "C")
+        val result = getFallbackCases(used, useCases, fallbackLimit = 4)
+        assert(!result.contains("B"))
     }
 }


### PR DESCRIPTION
Determines which use case IDs should be considered as fallback cases based on their usage history and defined limits.
