### PR TITLE
feat: add metadata field to LLMFunction declaration

### DIFF
--- a/arc-agents/src/main/kotlin/dsl/FunctionDefinitionContext.kt
+++ b/arc-agents/src/main/kotlin/dsl/FunctionDefinitionContext.kt
@@ -52,6 +52,7 @@ interface FunctionDefinitionContext {
         outputDescription: String? = null,
         params: ParametersSchema = ParametersSchema(),
         isSensitive: Boolean = false,
+        metadata: Map<String, Any> = emptyMap(),
         fn: suspend DSLContext.(List<Any?>) -> String,
     )
 }
@@ -109,6 +110,7 @@ class BasicFunctionDefinitionContext(private val beanProvider: BeanProvider) : F
         outputDescription: String?,
         params: ParametersSchema,
         isSensitive: Boolean,
+        metadata: Map<String, Any>,
         fn: suspend DSLContext.(List<Any?>) -> String,
     ) {
         functions.add(
@@ -121,6 +123,7 @@ class BasicFunctionDefinitionContext(private val beanProvider: BeanProvider) : F
                 isSensitive = isSensitive,
                 parameters = params,
                 context = BasicDSLContext(beanProvider),
+                metadata = metadata,
                 function = wrapOutput(fn),
             ),
         )

--- a/arc-agents/src/main/kotlin/functions/LLMFunction.kt
+++ b/arc-agents/src/main/kotlin/functions/LLMFunction.kt
@@ -20,6 +20,7 @@ interface LLMFunction {
     val group: String?
     val isSensitive: Boolean
     val outputDescription: String?
+    val metadata: Map<String, Any> get() = emptyMap()
 
     suspend fun execute(input: Map<String, Any?>): Result<String, LLMFunctionException>
 }

--- a/arc-agents/src/main/kotlin/functions/LambdaLLMFunction.kt
+++ b/arc-agents/src/main/kotlin/functions/LambdaLLMFunction.kt
@@ -22,6 +22,7 @@ data class LambdaLLMFunction(
     override val group: String?,
     override val isSensitive: Boolean,
     override val parameters: ParametersSchema,
+    override val metadata: Map<String, Any> = emptyMap(),
     private val context: DSLContext,
     private val function: suspend DSLContext.(List<Any?>) -> String,
 ) : LLMFunction, FunctionWithContext {

--- a/arc-graphql-spring-boot-starter/src/main/kotlin/InjectToolsFromRequest.kt
+++ b/arc-graphql-spring-boot-starter/src/main/kotlin/InjectToolsFromRequest.kt
@@ -119,6 +119,7 @@ class RequestFunctionProvider(private val request: AgentRequest, private val fun
                     override val group: String? = null
                     override val isSensitive: Boolean = false
                     override val outputDescription: String? = null
+                    override val metadata: Map<String, Any> = emptyMap()
                     override val parameters: ParametersSchema =
                         ParametersSchema(properties = parameters.associateBy { it.name!! })
 

--- a/arc-mcp/src/main/kotlin/McpTools.kt
+++ b/arc-mcp/src/main/kotlin/McpTools.kt
@@ -92,6 +92,7 @@ class ToolWrapper(
     override val description: String = tool.description
     override val group: String = "MCP"
     override val isSensitive: Boolean = false
+    override val metadata: Map<String, Any> get() = tool.meta()
 
     override suspend fun execute(input: Map<String, Any?>) = result<String, LLMFunctionException> {
         clientBuilder.execute { client, url ->

--- a/arc-mcp/src/test/kotlin/McpToolsTest.kt
+++ b/arc-mcp/src/test/kotlin/McpToolsTest.kt
@@ -23,6 +23,13 @@ class McpToolsTest : TestBase() {
     }
 
     @Test
+    fun `test tool metadata`(): Unit = runBlocking {
+        val tools = McpTools("http://localhost:$port", null).load(null)
+        val getBooksTool = tools.first { it.name == "getBooks" }
+        assertThat(getBooksTool.metadata["category"]).isEqualTo(listOf("books"))
+    }
+
+    @Test
     fun `test execute tool`(): Unit = runBlocking {
         val tools = McpTools("http://localhost:$port", null).load(null)
         val result = tools.first { it.name == "getBooks" }.execute(mapOf("id" to "Kotlin"))

--- a/arc-mcp/src/test/kotlin/TestApplication.kt
+++ b/arc-mcp/src/test/kotlin/TestApplication.kt
@@ -40,6 +40,7 @@ open class TestApplication {
         name = "getBooks",
         description = "description",
         params = types(string("id", "the id")),
+        metadata = mapOf("category" to listOf("books")),
     ) { (id) ->
         """[{"name":"Spring Boot"},{"name":"$id"}]"""
     }

--- a/arc-spring-boot-starter/src/main/kotlin/Functions.kt
+++ b/arc-spring-boot-starter/src/main/kotlin/Functions.kt
@@ -35,6 +35,7 @@ class Functions(private val beanProvider: BeanProvider) {
         isSensitive: Boolean = false,
         version: String? = null,
         outputDescription: String? = null,
+        metadata: Map<String, Any> = emptyMap(),
         fn: suspend DSLContext.(List<Any?>) -> String,
     ): LLMFunction {
         val context = BasicFunctionDefinitionContext(beanProvider)
@@ -46,6 +47,7 @@ class Functions(private val beanProvider: BeanProvider) {
             outputDescription = outputDescription,
             params = params,
             isSensitive = isSensitive,
+            metadata = metadata,
             fn = fn,
         )
         return context.functions.first()

--- a/arc-spring-boot-starter/src/main/kotlin/McpConfiguration.kt
+++ b/arc-spring-boot-starter/src/main/kotlin/McpConfiguration.kt
@@ -64,6 +64,7 @@ class McpConfiguration {
                                 .meta(
                                     buildMap {
                                         fn.version?.let { put("version", it) }
+                                        putAll(fn.metadata)
                                     },
                                 )
                                 .inputSchema(mcpMapper, fn.parameters.toJsonString())


### PR DESCRIPTION
Add metadata field to LLMFunction declarations. This metadata field can then be retrieved using MCP Tools.