### PR TITLE
Robust UseCaseIdExtractor

### DIFF
--- a/arc-assistants/src/main/kotlin/usecases/UseCaseIdExtractor.kt
+++ b/arc-assistants/src/main/kotlin/usecases/UseCaseIdExtractor.kt
@@ -8,13 +8,15 @@ typealias UseCaseId = String
 
 /**
  * Extract the use case id from the assistant message.
- * For example, "<ID:useCaseId>"
+ * For example, "<ID:useCaseId> "<UseCase:useCaseId>"
  */
 private val useCaseIdRegex = "<ID:(.*?)>".toRegex(RegexOption.IGNORE_CASE)
+private val useCaseIdRegex_alt = "<use[_]?case:(.*?)>".toRegex(RegexOption.IGNORE_CASE)
 
 fun extractUseCaseId(message: String): Pair<String, UseCaseId?> {
     val id = useCaseIdRegex.find(message)?.groupValues?.elementAtOrNull(1)?.trim()
-    val cleanedMessage = message.replace(useCaseIdRegex, "").trim()
+        ?: useCaseIdRegex_alt.find(message)?.groupValues?.elementAtOrNull(1)?.trim()
+    val cleanedMessage = message.replace(useCaseIdRegex, "").replace(useCaseIdRegex_alt, "").trim()
     return cleanedMessage to id
 }
 

--- a/arc-assistants/src/test/kotlin/usecases/UseCaseIdExtractorTest.kt
+++ b/arc-assistants/src/test/kotlin/usecases/UseCaseIdExtractorTest.kt
@@ -75,4 +75,21 @@ class UseCaseIdExtractorTest {
         assertThat(filteredMessage).contains("This is a reply from the LLM with <Dummy Data>")
         assertThat(useCaseId).isEqualTo("use_case01")
     }
+
+    @Test
+    fun `test usecase variant extraction`(): Unit = runBlocking {
+        val variants = listOf(
+            "<usecase:abc123> Message.",
+            "<UseCase:abc123> Message.",
+            "<use_case:abc123> Message.",
+            "<Use_Case:abc123> Message.",
+            "<USECASE:abc123> Message.",
+            "<USE_CASE:abc123> Message."
+        )
+        for (msg in variants) {
+            val (filteredMessage, useCaseId) = extractUseCaseId(msg)
+            assertThat(filteredMessage).contains("Message.")
+            assertThat(useCaseId).isEqualTo("abc123")
+        }
+    }
 }


### PR DESCRIPTION
To Extract similar usecase mentions like:

"<usecase:abc123>"
"<UseCase:abc123>"
"<use_case:abc123>"
"<Use_Case:abc123>"
"<USECASE:abc123>"
"<USE_CASE:abc123>"