### PR TITLE
Fix/gpt5 max completion tokens and usecase validation

### DIFF
--- a/arc-assistants/src/main/kotlin/filters/UseCaseResponseHandler.kt
+++ b/arc-assistants/src/main/kotlin/filters/UseCaseResponseHandler.kt
@@ -46,7 +46,7 @@ class UseCaseResponseHandler(
             // Try to match missing or unknown Use Case ids.
             val processedUseCases = getCurrentUseCases()?.processedUseCases
             if (useCaseId != null && processedUseCases != null && !processedUseCases.contains(useCaseId)) {
-                log.warn("Invalid use case id:[$useCaseId] detected! Processed use cases: [$processedUseCases]")
+                log.warn("Invalid use case id:[$useCaseId] detected!")
                 useCaseId = null
             }
             if (useCaseId == null && enforceUseCase && processedUseCases != null && !message.content.contains("NO_ANSWER")) {

--- a/arc-assistants/src/main/kotlin/filters/UseCaseResponseHandler.kt
+++ b/arc-assistants/src/main/kotlin/filters/UseCaseResponseHandler.kt
@@ -43,8 +43,12 @@ class UseCaseResponseHandler(
             // Store the current step in memory
             setUseCaseStep(stepId)
 
-            // Try to match missing Use Case ids.
+            // Try to match missing or unknown Use Case ids.
             val processedUseCases = getCurrentUseCases()?.processedUseCases
+            if (useCaseId != null && processedUseCases != null && !processedUseCases.contains(useCaseId)) {
+                log.warn("Invalid use case id:[$useCaseId] detected! Processed use cases: [$processedUseCases]")
+                useCaseId = null
+            }
             if (useCaseId == null && enforceUseCase && processedUseCases != null && !message.content.contains("NO_ANSWER")) {
                 log.info("No use case identified in message '${message.content}'. Attempting to classify...")
                 val transcript = input.transcript + message

--- a/arc-azure-client/src/main/kotlin/AzureAIClient.kt
+++ b/arc-azure-client/src/main/kotlin/AzureAIClient.kt
@@ -272,7 +272,14 @@ class AzureAIClient(
                     HIGH -> ReasoningEffortValue.HIGH
                 }
             }
-            settings?.maxTokens?.let { maxTokens = it }
+            settings?.maxTokens?.let { maxOutputTokens ->
+                val modelName = settings.deploymentNameOrModel() ?: config.modelName
+                if (requiresMaxCompletionTokens(modelName)) {
+                    maxCompletionTokens = maxOutputTokens
+                } else {
+                    maxTokens = maxOutputTokens
+                }
+            }
             settings?.format?.takeIf { JSON == it && responseFormat == null }
                 ?.let { responseFormat = ChatCompletionsJsonResponseFormat() }
             if (openAIFunctions != null) tools = openAIFunctions

--- a/arc-azure-client/src/main/kotlin/OpenAiChatParameters.kt
+++ b/arc-azure-client/src/main/kotlin/OpenAiChatParameters.kt
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.eclipse.lmos.arc.client.azure
+
+/**
+ * GPT-5 and o-series models reject `max_tokens` and require `max_completion_tokens`.
+ */
+internal fun requiresMaxCompletionTokens(modelName: String?): Boolean {
+    val model = modelName?.lowercase()?.replace('_', '-') ?: return false
+    return "gpt-5" in model || O_SERIES_MODEL.containsMatchIn(model)
+}
+
+private val O_SERIES_MODEL = Regex("""(?<![a-z0-9])o[1-4](?![a-z0-9])""")

--- a/arc-azure-client/src/test/kotlin/AzureAIClientTest.kt
+++ b/arc-azure-client/src/test/kotlin/AzureAIClientTest.kt
@@ -18,6 +18,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -25,6 +26,7 @@ import org.eclipse.lmos.arc.agents.conversation.UserMessage
 import org.eclipse.lmos.arc.agents.functions.LLMFunction
 import org.eclipse.lmos.arc.agents.functions.ParametersSchema
 import org.eclipse.lmos.arc.agents.llm.AIClientConfig
+import org.eclipse.lmos.arc.agents.llm.ChatCompletionSettings
 import org.eclipse.lmos.arc.core.Success
 import org.eclipse.lmos.arc.core.getOrThrow
 import org.junit.jupiter.api.Test
@@ -46,6 +48,36 @@ class AzureAIClientTest {
 
         verify(exactly = 1) { azureClient.getChatCompletions(any(), any()) }
         assertThat(result.content).isEqualTo("answer")
+    }
+
+    @Test
+    fun `maps maxTokens to maxCompletionTokens for gpt-5 models`(): Unit = runBlocking {
+        val azureClient = mockk<OpenAIAsyncClient>()
+        val options = slot<com.azure.ai.openai.models.ChatCompletionsOptions>()
+        val gpt54 = AIClientConfig(client = "azure", endpoint = "url", apiKey = "apiKey", modelName = "GPT-5.4")
+        every { azureClient.getChatCompletions(gpt54.modelName, capture(options)) } returns finalChatCompletions()
+
+        AzureAIClient(gpt54, azureClient).complete(
+            listOf(UserMessage("Hello")),
+            settings = ChatCompletionSettings(maxTokens = 256),
+        ).getOrThrow()
+
+        assertThat(options.captured.getMaxCompletionTokens()).isEqualTo(256)
+    }
+
+    @Test
+    fun `keeps maxTokens for gpt-4o models`(): Unit = runBlocking {
+        val azureClient = mockk<OpenAIAsyncClient>()
+        val options = slot<com.azure.ai.openai.models.ChatCompletionsOptions>()
+        val gpt4o = AIClientConfig(client = "azure", endpoint = "url", apiKey = "apiKey", modelName = "GPT-4o")
+        every { azureClient.getChatCompletions(gpt4o.modelName, capture(options)) } returns finalChatCompletions()
+
+        AzureAIClient(gpt4o, azureClient).complete(
+            listOf(UserMessage("Hello")),
+            settings = ChatCompletionSettings(maxTokens = 256),
+        ).getOrThrow()
+
+        assertThat(options.captured.getMaxTokens()).isEqualTo(256)
     }
 
     @Test

--- a/arc-azure-client/src/test/kotlin/OpenAiChatParametersTest.kt
+++ b/arc-azure-client/src/test/kotlin/OpenAiChatParametersTest.kt
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.eclipse.lmos.arc.client.azure
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OpenAiChatParametersTest {
+
+    @Test
+    fun `gpt-5 family requires max_completion_tokens`() {
+        assertThat(requiresMaxCompletionTokens("GPT-5.4")).isTrue()
+        assertThat(requiresMaxCompletionTokens("gpt-5.4-mini")).isTrue()
+        assertThat(requiresMaxCompletionTokens("GPT-5")).isTrue()
+        assertThat(requiresMaxCompletionTokens("o1-mini")).isTrue()
+        assertThat(requiresMaxCompletionTokens("o3")).isTrue()
+        assertThat(requiresMaxCompletionTokens("o4-mini")).isTrue()
+    }
+
+    @Test
+    fun `gpt-4 family keeps max_tokens`() {
+        assertThat(requiresMaxCompletionTokens("GPT-4o")).isFalse()
+        assertThat(requiresMaxCompletionTokens("gpt-4.1")).isFalse()
+        assertThat(requiresMaxCompletionTokens("GPT-4o-mini")).isFalse()
+        assertThat(requiresMaxCompletionTokens(null)).isFalse()
+    }
+}


### PR DESCRIPTION
GPT-5/o-series reject max_tokens; AzureAIClient now sends max_completion_tokens for those models. 

UseCaseResponseHandler clears unknown SOP ids so enforceUseCase can run the matcher.